### PR TITLE
Quiet warnings and add ruby 2.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,7 @@ before_install:
   - gem install bundler
 language: ruby
 rvm:
-  - 1.9.2
-  - 1.9.3
-  - 2.0.0
   - 2.1.7
   - 2.2.3
   - 2.3.1
+  - 2.4.1

--- a/lib/memoizer.rb
+++ b/lib/memoizer.rb
@@ -9,7 +9,7 @@ module Memoizer
   end
 
   def self.ivar_name(method_name)
-    "_memoized_#{self.safe_name(method_name)}"
+    :"@_memoized_#{self.safe_name(method_name)}"
   end
 
   module ClassMethods
@@ -24,15 +24,15 @@ module Memoizer
 
         define_method method_name do |*args|
 
-          if instance_variable_defined?("@#{memoized_ivar_name}")
-            memoized_value = self.instance_variable_get("@#{memoized_ivar_name}")
+          if instance_variable_defined?(memoized_ivar_name)
+            memoized_value = self.instance_variable_get(memoized_ivar_name)
           end
 
           # if the method takes no inputs, store the value in an array
           if no_args
             if !memoized_value.is_a?(Array)
               memoized_value = [self.send(unmemoized_method)]
-              self.instance_variable_set("@#{memoized_ivar_name}", memoized_value)
+              self.instance_variable_set(memoized_ivar_name, memoized_value)
             end
             memoized_value.first
 
@@ -40,7 +40,7 @@ module Memoizer
           else
             if !memoized_value.is_a?(Hash)
               memoized_value = {args => self.send(unmemoized_method, *args)}
-              self.instance_variable_set("@#{memoized_ivar_name}", memoized_value)
+              self.instance_variable_set(memoized_ivar_name, memoized_value)
             elsif !memoized_value.has_key?(args)
               memoized_value[args] = self.send(unmemoized_method, *args)
             end
@@ -59,7 +59,7 @@ module Memoizer
 
   module InstanceMethods
     def unmemoize(method_name)
-      self.instance_variable_set("@#{Memoizer.ivar_name(method_name)}", nil)
+      self.instance_variable_set(Memoizer.ivar_name(method_name), nil)
     end
 
     def unmemoize_all

--- a/lib/memoizer.rb
+++ b/lib/memoizer.rb
@@ -24,7 +24,10 @@ module Memoizer
         no_args = self.instance_method(unmemoized_method).arity == 0
 
         define_method method_name do |*args|
-          memoized_value = self.instance_variable_get("@#{memoized_ivar_name}")
+
+          if instance_variable_defined?("@#{memoized_ivar_name}")
+            memoized_value = self.instance_variable_get("@#{memoized_ivar_name}")
+          end
 
           # if the method takes no inputs, store the value in an array
           if no_args

--- a/lib/memoizer.rb
+++ b/lib/memoizer.rb
@@ -18,7 +18,6 @@ module Memoizer
         memoized_ivar_name = Memoizer.ivar_name(method_name)
         unmemoized_method = "_unmemoized_#{method_name}"
 
-        attr_accessor memoized_ivar_name
         alias_method unmemoized_method, method_name
 
         no_args = self.instance_method(unmemoized_method).arity == 0

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,3 +2,7 @@ require 'rubygems'
 require 'bundler/setup'
 require 'date'
 require 'timecop'
+
+RSpec.configure do |config|
+  config.warnings = true
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,4 +5,6 @@ require 'timecop'
 
 RSpec.configure do |config|
   config.warnings = true
+  config.order = :random
+  Kernel.srand config.seed
 end


### PR DESCRIPTION
* Enable ruby warnings in this gem's specs, and check to see if the memoized ivar is defined before accessing it. This will quiet the flood of warnings in other projects that have warnings enabled.
* Update the CI build matrix to remove unsupported rubies and add 2.4
* Start returning a symbol from `Memoizer.ivar_name`, and some cleanup to support that.