### PR TITLE
Fix double memoization bug

### DIFF
--- a/lib/memoizer.rb
+++ b/lib/memoizer.rb
@@ -14,14 +14,14 @@ module Memoizer
 
   module ClassMethods
     def memoize(*method_names)
-      @memoizer_memoized_methods ||= []
+      @memoizer_memoized_methods ||= {}
 
       method_names.each do |method_name|
         # If the method is already memoized, don't do anything
-        if @memoizer_memoized_methods.include?(method_name)
+        if @memoizer_memoized_methods[method_name]
           next
         else
-          @memoizer_memoized_methods << method_name
+          @memoizer_memoized_methods[method_name] = true
         end
 
         memoized_ivar_name = Memoizer.ivar_name(method_name)

--- a/lib/memoizer.rb
+++ b/lib/memoizer.rb
@@ -14,7 +14,16 @@ module Memoizer
 
   module ClassMethods
     def memoize(*method_names)
+      @memoizer_memoized_methods ||= []
+
       method_names.each do |method_name|
+        # If the method is already memoized, don't do anything
+        if @memoizer_memoized_methods.include?(method_name)
+          next
+        else
+          @memoizer_memoized_methods << method_name
+        end
+
         memoized_ivar_name = Memoizer.ivar_name(method_name)
         unmemoized_method = "_unmemoized_#{method_name}"
 

--- a/lib/memoizer/version.rb
+++ b/lib/memoizer/version.rb
@@ -1,3 +1,3 @@
 module Memoizer
-  VERSION = '1.0.3'
+  VERSION = '1.0.4'
 end

--- a/spec/memoizer_spec.rb
+++ b/spec/memoizer_spec.rb
@@ -3,6 +3,7 @@ class MemoizerSpecClass
   def no_params() Date.today; end
   def with_params?(ndays, an_array) Date.today + ndays + an_array.length; end
   def returning_nil!() Date.today; nil; end
+  def double_memoized() Date.today; end
 
   def with_hash_parameter(ndays, options = {})
     subtract = options.fetch(:subtract, false)
@@ -69,11 +70,14 @@ class MemoizerSpecClass
   memoize :no_params,
           :with_params?,
           :returning_nil!,
+          :double_memoized,
           :with_hash_and_kwargs,
           :with_hash_parameter,
           :with_only_hash_parameter,
           :with_kwargs,
           :with_only_kwargs
+
+  memoize :double_memoized
 end
 class Beepbop < MemoizerSpecClass; end
 
@@ -90,6 +94,15 @@ describe Memoizer do
         expect(object.no_params).to eq(today)
         Timecop.freeze(tomorrow)
         expect(object.no_params).to eq(today)
+      end
+    end
+
+    context "for a double-memoized method" do
+      it "works the same as a calling memoize once" do
+        Timecop.freeze(today)
+        expect(object.double_memoized).to eq(today)
+        Timecop.freeze(tomorrow)
+        expect(object.double_memoized).to eq(today)
       end
     end
 


### PR DESCRIPTION
From the relevant commit:

> Previously, calling `memoize` with the same method name more than once would
result in a perpetual loop when calling that method. This commit fixes the bug.
Memoizer now keeps track of which methods have been memoized and avoids trying
to memoize an already-memoized method.