### PR TITLE
Preserve arity of memoized methods

### DIFF
--- a/lib/memoizer.rb
+++ b/lib/memoizer.rb
@@ -26,7 +26,7 @@ module Memoizer
         when 0
           module_eval(<<-RUBY)
             def #{method_name}()
-              #{memoized_ivar_name} ||= [send(:#{unmemoized_method})]
+              #{memoized_ivar_name} ||= [#{unmemoized_method}()]
               #{memoized_ivar_name}.first
             end
           RUBY
@@ -38,7 +38,7 @@ module Memoizer
               if #{memoized_ivar_name}.has_key?(args)
                 #{memoized_ivar_name}[args]
               else
-                #{memoized_ivar_name}[args] = send(:#{unmemoized_method}, *args)
+                #{memoized_ivar_name}[args] = #{unmemoized_method}(*args)
               end
             end
           RUBY
@@ -54,7 +54,7 @@ module Memoizer
               if #{memoized_ivar_name}.has_key?(args)
                 #{memoized_ivar_name}[args]
               else
-                #{memoized_ivar_name}[args] = send(:#{unmemoized_method}, #{args_ruby})
+                #{memoized_ivar_name}[args] = #{unmemoized_method}(#{args_ruby})
               end
             end
           RUBY

--- a/spec/memoizer_spec.rb
+++ b/spec/memoizer_spec.rb
@@ -106,6 +106,48 @@ describe Memoizer do
       end
     end
 
+    context 'for methods with an arity of 0' do
+      class Arity0 < MemoizerSpecClass
+        def foo()
+        end
+
+        memoize :foo
+      end
+
+      it 'creates a memoized method with an arity of 0' do
+        expect(Arity0.instance_method(:foo).arity).to eq(0)
+      end
+
+    end
+
+    context 'for methods with an arity of 2' do
+      class Arity2 < MemoizerSpecClass
+        def foo(a, b)
+        end
+
+        memoize :foo
+      end
+
+      it 'creates a memoized method with an arity of 2' do
+        expect(Arity2.instance_method(:foo).arity).to eq(2)
+      end
+
+    end
+
+    context 'for methods with splat args' do
+      class AritySplat < MemoizerSpecClass
+        def foo(*args)
+        end
+
+        memoize :foo
+      end
+
+      it 'creates a memoized method with an arity of -1' do
+        expect(AritySplat.instance_method(:foo).arity).to eq(-1)
+      end
+
+    end
+
   end
 
 


### PR DESCRIPTION
Thanks for maintaining this library.

An issue that we with `Memoizer` is that a method's arity is always -1 after memoizing. This is due to Memoizer overriding the original method with `define_method method_name do |*args|`. The arity of a splat-args method is always -1.

The PR changes Memoizer so it preserves the arity of memoized methods.

It also improves the performance of memoized methods by defining the memoized method with a `define_method` closure.

Please consider this change for your gem.