### PR TITLE
Test memoizer on supported versions of ruby

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ before_install:
   - gem install bundler
 language: ruby
 rvm:
-  - 2.1.7
-  - 2.2.3
-  - 2.3.1
-  - 2.4.1
+  - 2.5.8
+  - 2.6.6
+  - 2.7.1

--- a/memoizer.gemspec
+++ b/memoizer.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.extra_rdoc_files = ["README.md", "LICENSE.txt"]
   s.license = 'MIT'
 
-  s.add_development_dependency('rake', '~> 10.4.2')
-  s.add_development_dependency('rspec', '~> 3.5.0')
-  s.add_development_dependency('timecop', '~> 0.8.0')
+  s.add_development_dependency('rake', '~> 13.0')
+  s.add_development_dependency('rspec', '~> 3.9')
+  s.add_development_dependency('timecop', '~> 0.9.1')
 end


### PR DESCRIPTION
This PR updates our travis CI build matrix to only test against the currently supported major versions of ruby. Older versions of the gem should continue to work on unsupported rubies.