### PR TITLE
Add support for ruby 2 keyword args

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -1,0 +1,27 @@
+name: Ruby
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        ruby-version: ['2.6', '2.7', '3.0', '3.1']
+
+    steps:
+    - name: Checkout Repository
+      uses: actions/checkout@v2
+
+    - name: Set up Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: ${{ matrix.ruby-version }}
+        bundler-cache: true
+
+    - name: Run tests
+      run: bundle exec rake test

--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,1 @@
+--require spec_helper

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,0 @@
----
-before_install:
-  - gem install bundler
-language: ruby
-rvm:
-  - 2.5.8
-  - 2.6.6
-  - 2.7.1

--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-[![Build Status](https://travis-ci.org/wegowise/memoizer.svg?branch=setup-travis-ci)](https://travis-ci.org/wegowise/memoizer)
-
 # memoizer
 
 Memoizer will memoize the results of your methods. It acts much like

--- a/lib/memoizer.rb
+++ b/lib/memoizer.rb
@@ -47,6 +47,7 @@ module Memoizer
             memoized_value[args]
           end
         end
+        ruby2_keywords method_name if respond_to?(:ruby2_keywords, true)
 
         if self.private_method_defined?(unmemoized_method)
           private method_name

--- a/spec/memoizer_spec.rb
+++ b/spec/memoizer_spec.rb
@@ -1,5 +1,3 @@
-require 'memoizer'
-
 class MemoizerSpecClass
   include Memoizer
   def no_params() Date.today; end

--- a/spec/memoizer_spec.rb
+++ b/spec/memoizer_spec.rb
@@ -1,5 +1,4 @@
 require 'memoizer'
-require 'spec_helper'
 
 class MemoizerSpecClass
   include Memoizer

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,7 @@
 require 'rubygems'
 require 'bundler/setup'
 require 'date'
+require 'memoizer'
 require 'timecop'
 
 RSpec.configure do |config|

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,6 +4,8 @@ require 'date'
 require 'memoizer'
 require 'timecop'
 
+Warning[:deprecated] = true if Warning.respond_to?(:[]=)
+
 RSpec.configure do |config|
   config.warnings = true
   config.order = :random


### PR DESCRIPTION
This PR improves support for [the ruby keyword argument changes across 2.6, 2.7, and 3.0+](https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/). Currently, the best way to accomplish this without dropping support for ruby 2.6 is to call `ruby2_keywords` with the name of the method defined by memoizer. In a future version of this gem, we will need to drop `ruby2_keywords`, and thus, drop support for ruby 2.6.

Since travis-ci.org is no longer building open source projects, this PR also reconfigures CI for this gem to use GitHub Actions. EOL'd versions of ruby have been removed from CI.
